### PR TITLE
Comment out undefined 'URLs' var, fixed urlify() function

### DIFF
--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -142,12 +142,9 @@ onlineSync = (method, model, options) ->
   # Make the request.
   $.ajax params
 
-urlify = (model) ->
-  if _.isFunction(model.url) then model.url() else model.url
-
 dualsync = (method, model, options) ->
   console.log 'dualsync', method, model, options
-  store = new Store urlify(model)
+  store = new Store getUrl(model)
 
   switch method
     when 'read'


### PR DESCRIPTION
`URLs` is undefined when testing on Chrome. Additionally, `urlify()` breaks for me if `model.url` is a function. I changed `urlify()` and the call to it to accept `model` and test whether `model.url` is a function (rather than just passing `model.url` into it and testing whether `url` is a function).
