### PR TITLE
Added an option to assign a model or collection a "storeName" attribute to be used as a localstorage key instead of its url

### DIFF
--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -185,7 +185,8 @@ onlineSync = Backbone.sync
 dualsync = (method, model, options) ->
   console.log 'dualsync', method, model, options
   
-  options.storeName = result(model.collection, 'url') || result(model, 'url')
+  options.storeName = result(model.collection, 'storeName') || result(model, 'storeName') || 
+                      result(model.collection, 'url') || result(model, 'url')
   
   # execute only online sync
   return onlineSync(method, model, options) if result(model, 'remote') or result(model.collection, 'remote')

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -240,7 +240,7 @@
   dualsync = function(method, model, options) {
     var error, local, originalModel, success;
     console.log('dualsync', method, model, options);
-    options.storeName = result(model.collection, 'url') || result(model, 'url');
+    options.storeName = result(model.collection, 'storeName') || result(model, 'storeName') || result(model.collection, 'url') || result(model, 'url');
     if (result(model, 'remote') || result(model.collection, 'remote')) {
       return onlineSync(method, model, options);
     }


### PR DESCRIPTION
Should not affect any preexisting code.

Example usage:

```
var RecordList = Backbone.Collection.extend({
  model: Record,
  storeName: 'RecordList',
});
```
