### PR TITLE
Fetch with add: true

### DIFF
--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -143,8 +143,9 @@ localsync = (method, model, options) ->
     when 'clear'
       store.clear()
     when 'create'
-      model = store.create(model)
-      store.dirty(model) if options.dirty
+      unless options.add and not options.merge and store.find(model)
+        model = store.create(model)
+        store.dirty(model) if options.dirty
     when 'update'
       store.update(model)
       if options.dirty then store.dirty(model) else store.clean(model, 'dirty')


### PR DESCRIPTION
This patch fixes a bug where using `fetch(add: true)` replaces the entire collection in localStorage with the models that get added, rather than adding those models to what is already in localStorage.

Passing `add: true` to fetch tells fetch to add the models in the sync response to the collection, rather than using reset.

Normally, `Collection.add` will ignore models that already exist in the collection. The second commit accounts for that.

In the next version of Backbone, you can also call `fetch(add: true, merge: true)` to update existing models rather than ignoring those adds. This patch also accounts for that. See: https://github.com/documentcloud/backbone/commit/9ee0358cd66001b7140fa89208f441635a0c19bf
