### PR TITLE
Fix failing test for model update with custom id attribute.

### DIFF
--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -278,8 +278,8 @@ dualsync = (method, model, options) ->
         onlineSync('create', model, options)
       else
         options.success = (resp, status, xhr) ->
-          updatedAttributes = _.extend({}, model.toJSON(), resp)
-          localsync(method, updatedAttributes, options)
+          model.set model.parse resp
+          localsync(method, model, options)
           success(resp, status, xhr)
         options.error = (resp) ->
           options.dirty = true

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -355,9 +355,8 @@ as that.
           return onlineSync('create', model, options);
         } else {
           options.success = function(resp, status, xhr) {
-            var updatedAttributes;
-            updatedAttributes = _.extend({}, model.toJSON(), resp);
-            localsync(method, updatedAttributes, options);
+            model.set(model.parse(resp));
+            localsync(method, model, options);
             return success(resp, status, xhr);
           };
           options.error = function(resp) {

--- a/spec/backbone.dualstorage.js
+++ b/spec/backbone.dualstorage.js
@@ -353,9 +353,8 @@ dualsync = function(method, model, options) {
         return onlineSync('create', model, options);
       } else {
         options.success = function(resp, status, xhr) {
-          var updatedAttributes;
-          updatedAttributes = _.extend({}, model.toJSON(), resp);
-          localsync(method, updatedAttributes, options);
+          model.set(model.parse(resp));
+          localsync(method, model, options);
           return success(resp, status, xhr);
         };
         options.error = function(resp) {

--- a/spec/dualsync_spec.coffee
+++ b/spec/dualsync_spec.coffee
@@ -68,7 +68,7 @@ describe 'delegating to localsync and backboneSync, and calling the model callba
             id: 12
             position: 'arm'
             updated: 'by the server'
-          expect(localsync.calls[0].args[1]).toEqual(mergedAttributes)
+          expect(localsync.calls[0].args[1].attributes).toEqual(mergedAttributes)
 
     describe 'delete', ->
       it 'delegates to both localsync and backboneSync', ->

--- a/spec/dualsync_spec.js
+++ b/spec/dualsync_spec.js
@@ -131,7 +131,7 @@
               position: 'arm',
               updated: 'by the server'
             };
-            return expect(localsync.calls[0].args[1]).toEqual(mergedAttributes);
+            return expect(localsync.calls[0].args[1].attributes).toEqual(mergedAttributes);
           });
         });
       });


### PR DESCRIPTION
This commit fixes a failing test for model updates with a custom id
attribute. It changes the strategy how updated fields from server-side
are merged with locally synced models. Instead of merging objects with
`_.extend()`, the received response is merged through `set()` method.
## Background

As far as I can judge (I'm very new to the codebase), this issue might
have been introduced with [PR36](https://github.com/nilbus/Backbone.dualStorage/pull/36), which introduced merging model after
update. Changing the type of the second argument to `localsync` from
_bb.Model_ to _object_ seemed to cause the unwanted side effect that the
custom id attribute is no longer discoverable from within `localsync`.

Hence, the fixing strategy has been developed around the idea to adhere
to `localsync` type signature. The easiest solution seems to just
overwrite the existing local model instance with the received response
from server through `model.set()`, after previously having parsed the
response through `model.parse()` (just to be compatible to the overall
idea of being agnostic from response formats).
## Motivation

I developed this fix in order to get the test suite to all green back
again. I stumbled over the failing test after I checked out the code for
investigation (in pursuit of a completely unrelated thing).
## Notes

This is my first contribution to the codebase. Please review my change
thoroughly. I ran the test suite against Chromium and Firefox browsers.
Thanks for your efforts on backbone.dualStorage!
