### PR TITLE
Guard against JSON.parse(null) to workaround issue on Android 2.3

### DIFF
--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -111,7 +111,9 @@ class window.Store
 
   # Retrieve a model from `this.data` by id.
   find: (model) ->
-    JSON.parse localStorage.getItem(@name + @sep + model.id)
+    modelAsJson = localStorage.getItem(@name + @sep + model.id)
+    return null if modelAsJson == null
+    JSON.parse modelAsJson
 
   # Return the array of all models currently in storage.
   findAll: ->

--- a/spec/localstorage_store_spec.coffee
+++ b/spec/localstorage_store_spec.coffee
@@ -14,8 +14,19 @@ describe 'window.Store', ->
       expect(store.name).toBe 'convenience store'
 
   describe 'persistence', ->
-    it 'fetches records by id with find', ->
-      expect(store.find(id: 3)).toEqual id: '3', color: 'burgundy'
+    describe 'find', ->
+      it 'fetches records by id', ->
+        expect(store.find(id: 3)).toEqual id: '3', color: 'burgundy'
+
+      # JSON.parse(null) causes error on Android 2.x devices, so it should be avoided
+      it 'does not try to JSON.parse null values', ->
+        spyOn JSON, 'parse'
+        store.find id: 'unpersistedId'
+        expect(JSON.parse).not.toHaveBeenCalledWith(null)
+
+      it 'returns null when not found', ->
+        result = store.find(id: 'unpersistedId')
+        expect(result).toBeNull()
 
     it 'fetches all records with findAll', ->
       expect(store.findAll()).toEqual [id: '3', color: 'burgundy']


### PR DESCRIPTION
At least on Android 2.3.x webviews, trying to `JSON.parse(null)` results in an error.

This pull request avoid the parsing when the value read from localStorage is null.

Includes tests to assert that:
- JSON.parse(null) is avoided
- we still return `null` like the curent implementation when running on modern browsers
