### PR TITLE
Dirty and destroyed should also check storeName items

### DIFF
--- a/backbone.dualstorage.amd.js
+++ b/backbone.dualstorage.amd.js
@@ -21,9 +21,10 @@ as that.
 var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
 Backbone.Collection.prototype.syncDirty = function() {
-  var id, ids, model, store, url, _i, _len, _results;
+  var id, ids, model, store, storeName, url, _i, _len, _results;
   url = result(this, 'url');
-  store = localStorage.getItem("" + url + "_dirty");
+  storeName = result(this, 'storeName');
+  store = localStorage.getItem(("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty"));
   ids = (store && store.split(',')) || [];
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {
@@ -37,9 +38,10 @@ Backbone.Collection.prototype.syncDirty = function() {
 };
 
 Backbone.Collection.prototype.syncDestroyed = function() {
-  var id, ids, model, store, url, _i, _len, _results;
+  var id, ids, model, store, storeName, url, _i, _len, _results;
   url = result(this, 'url');
-  store = localStorage.getItem("" + url + "_destroyed");
+  storeName = result(this, 'storeName');
+  store = localStorage.getItem(("" + url + "_destroyed") || (store = localStorage.getItem("" + storeName + "_destroyed")));
   ids = (store && store.split(',')) || [];
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {

--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -10,7 +10,8 @@ as that.
 # Simply call collection.syncDirtyAndDestroyed()
 Backbone.Collection.prototype.syncDirty = ->
   url = result(@, 'url')
-  store = localStorage.getItem "#{url}_dirty"
+  storeName = result(@, 'storeName')
+  store = localStorage.getItem "#{url}_dirty" || localStorage.getItem "#{storeName}_dirty"
   ids = (store and store.split(',')) or []
 
   for id in ids
@@ -19,7 +20,8 @@ Backbone.Collection.prototype.syncDirty = ->
 
 Backbone.Collection.prototype.syncDestroyed = ->
   url = result(@, 'url')
-  store = localStorage.getItem "#{url}_destroyed"
+  storeName = result(@, 'storeName')
+  store = localStorage.getItem "#{url}_destroyed" || store = localStorage.getItem "#{storeName}_destroyed"
   ids = (store and store.split(',')) or []
 
   for id in ids

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -12,9 +12,10 @@ as that.
   var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
   Backbone.Collection.prototype.syncDirty = function() {
-    var id, ids, model, store, url, _i, _len, _results;
+    var id, ids, model, store, storeName, url, _i, _len, _results;
     url = result(this, 'url');
-    store = localStorage.getItem("" + url + "_dirty");
+    storeName = result(this, 'storeName');
+    store = localStorage.getItem(("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty"));
     ids = (store && store.split(',')) || [];
     _results = [];
     for (_i = 0, _len = ids.length; _i < _len; _i++) {
@@ -28,9 +29,10 @@ as that.
   };
 
   Backbone.Collection.prototype.syncDestroyed = function() {
-    var id, ids, model, store, url, _i, _len, _results;
+    var id, ids, model, store, storeName, url, _i, _len, _results;
     url = result(this, 'url');
-    store = localStorage.getItem("" + url + "_destroyed");
+    storeName = result(this, 'storeName');
+    store = localStorage.getItem(("" + url + "_destroyed") || (store = localStorage.getItem("" + storeName + "_destroyed")));
     ids = (store && store.split(',')) || [];
     _results = [];
     for (_i = 0, _len = ids.length; _i < _len; _i++) {

--- a/spec/backbone.dualstorage.js
+++ b/spec/backbone.dualstorage.js
@@ -10,9 +10,10 @@ as that.
 var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
 Backbone.Collection.prototype.syncDirty = function() {
-  var id, ids, model, store, url, _i, _len, _results;
+  var id, ids, model, store, storeName, url, _i, _len, _results;
   url = result(this, 'url');
-  store = localStorage.getItem("" + url + "_dirty");
+  storeName = result(this, 'storeName');
+  store = localStorage.getItem(("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty"));
   ids = (store && store.split(',')) || [];
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {
@@ -26,9 +27,10 @@ Backbone.Collection.prototype.syncDirty = function() {
 };
 
 Backbone.Collection.prototype.syncDestroyed = function() {
-  var id, ids, model, store, url, _i, _len, _results;
+  var id, ids, model, store, storeName, url, _i, _len, _results;
   url = result(this, 'url');
-  store = localStorage.getItem("" + url + "_destroyed");
+  storeName = result(this, 'storeName');
+  store = localStorage.getItem(("" + url + "_destroyed") || (store = localStorage.getItem("" + storeName + "_destroyed")));
   ids = (store && store.split(',')) || [];
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {


### PR DESCRIPTION
syncDirty and syncDestroyed get the localStorage item by their URL identifiers. When you use a storeName prefix, these functions can't find the localStorage item. 
This PR just patches the functions to also check storeName.
