### PR TITLE
Encapsulate persisted logic into a Model method

### DIFF
--- a/backbone.dualstorage.amd.js
+++ b/backbone.dualstorage.amd.js
@@ -20,8 +20,12 @@ as that.
 
 var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
+Backbone.Model.prototype.hasTempId = function() {
+  return _.isString(this.id) && this.id.length === 36;
+};
+
 Backbone.Collection.prototype.syncDirty = function() {
-  var id, ids, model, store, storeName, url, _i, _len, _results;
+  var id, ids, store, storeName, url, _i, _len, _ref, _results;
   url = result(this, 'url');
   storeName = result(this, 'storeName');
   store = localStorage.getItem("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty");
@@ -29,10 +33,7 @@ Backbone.Collection.prototype.syncDirty = function() {
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {
     id = ids[_i];
-    model = id.length === 36 ? this.findWhere({
-      id: id
-    }) : this.get(id);
-    _results.push(model != null ? model.save() : void 0);
+    _results.push((_ref = this.get(id)) != null ? _ref.save() : void 0);
   }
   return _results;
 };
@@ -380,7 +381,7 @@ dualsync = function(method, model, options) {
       };
       return onlineSync(method, model, options);
     case 'update':
-      if (_.isString(model.id) && model.id.length === 36) {
+      if (model.hasTempId()) {
         temporaryId = model.id;
         options.success = function(resp, status, xhr) {
           var updatedModel;
@@ -418,7 +419,7 @@ dualsync = function(method, model, options) {
       }
       break;
     case 'delete':
-      if (_.isString(model.id) && model.id.length === 36) {
+      if (model.hasTempId()) {
         return localsync(method, model, options);
       } else {
         options.success = function(resp, status, xhr) {

--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -6,6 +6,9 @@ persistence. Models are given GUIDS, and saved into a JSON object. Simple
 as that.
 ###
 
+Backbone.Model.prototype.hasTempId = ->
+  _.isString(@id) and @id.length is 36
+
 # Make it easy for collections to sync dirty and destroyed records
 # Simply call collection.syncDirtyAndDestroyed()
 Backbone.Collection.prototype.syncDirty = ->
@@ -15,8 +18,7 @@ Backbone.Collection.prototype.syncDirty = ->
   ids = (store and store.split(',')) or []
 
   for id in ids
-    model = if id.length == 36 then @findWhere(id: id) else @get(id)
-    model?.save()
+    @get(id)?.save()
 
 Backbone.Collection.prototype.syncDestroyed = ->
   url = result(@, 'url')
@@ -289,7 +291,7 @@ dualsync = (method, model, options) ->
       onlineSync(method, model, options)
 
     when 'update'
-      if _.isString(model.id) and model.id.length == 36
+      if model.hasTempId()
         temporaryId = model.id
 
         options.success = (resp, status, xhr) ->
@@ -317,7 +319,7 @@ dualsync = (method, model, options) ->
         onlineSync(method, model, options)
 
     when 'delete'
-      if _.isString(model.id) and model.id.length == 36
+      if model.hasTempId()
         localsync(method, model, options)
       else
         options.success = (resp, status, xhr) ->

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -11,8 +11,12 @@ as that.
 (function() {
   var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
+  Backbone.Model.prototype.hasTempId = function() {
+    return _.isString(this.id) && this.id.length === 36;
+  };
+
   Backbone.Collection.prototype.syncDirty = function() {
-    var id, ids, model, store, storeName, url, _i, _len, _results;
+    var id, ids, store, storeName, url, _i, _len, _ref, _results;
     url = result(this, 'url');
     storeName = result(this, 'storeName');
     store = localStorage.getItem("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty");
@@ -20,10 +24,7 @@ as that.
     _results = [];
     for (_i = 0, _len = ids.length; _i < _len; _i++) {
       id = ids[_i];
-      model = id.length === 36 ? this.findWhere({
-        id: id
-      }) : this.get(id);
-      _results.push(model != null ? model.save() : void 0);
+      _results.push((_ref = this.get(id)) != null ? _ref.save() : void 0);
     }
     return _results;
   };
@@ -371,7 +372,7 @@ as that.
         };
         return onlineSync(method, model, options);
       case 'update':
-        if (_.isString(model.id) && model.id.length === 36) {
+        if (model.hasTempId()) {
           temporaryId = model.id;
           options.success = function(resp, status, xhr) {
             var updatedModel;
@@ -409,7 +410,7 @@ as that.
         }
         break;
       case 'delete':
-        if (_.isString(model.id) && model.id.length === 36) {
+        if (model.hasTempId()) {
           return localsync(method, model, options);
         } else {
           options.success = function(resp, status, xhr) {

--- a/spec/backbone.dualstorage.js
+++ b/spec/backbone.dualstorage.js
@@ -9,8 +9,12 @@ as that.
 
 var S4, backboneSync, callbackTranslator, dualsync, localsync, modelUpdatedWithResponse, onlineSync, parseRemoteResponse, result;
 
+Backbone.Model.prototype.hasTempId = function() {
+  return _.isString(this.id) && this.id.length === 36;
+};
+
 Backbone.Collection.prototype.syncDirty = function() {
-  var id, ids, model, store, storeName, url, _i, _len, _results;
+  var id, ids, store, storeName, url, _i, _len, _ref, _results;
   url = result(this, 'url');
   storeName = result(this, 'storeName');
   store = localStorage.getItem("" + url + "_dirty") || localStorage.getItem("" + storeName + "_dirty");
@@ -18,10 +22,7 @@ Backbone.Collection.prototype.syncDirty = function() {
   _results = [];
   for (_i = 0, _len = ids.length; _i < _len; _i++) {
     id = ids[_i];
-    model = id.length === 36 ? this.findWhere({
-      id: id
-    }) : this.get(id);
-    _results.push(model != null ? model.save() : void 0);
+    _results.push((_ref = this.get(id)) != null ? _ref.save() : void 0);
   }
   return _results;
 };
@@ -369,7 +370,7 @@ dualsync = function(method, model, options) {
       };
       return onlineSync(method, model, options);
     case 'update':
-      if (_.isString(model.id) && model.id.length === 36) {
+      if (model.hasTempId()) {
         temporaryId = model.id;
         options.success = function(resp, status, xhr) {
           var updatedModel;
@@ -407,7 +408,7 @@ dualsync = function(method, model, options) {
       }
       break;
     case 'delete':
-      if (_.isString(model.id) && model.id.length === 36) {
+      if (model.hasTempId()) {
         return localsync(method, model, options);
       } else {
         options.success = function(resp, status, xhr) {


### PR DESCRIPTION
Right now Backbone.dualStorage infers a model is persisted if it's id
length is not 36 characters.

With this change applications can decide how to compute if a model is
persisted or not (checking for a `created_at` attribute for example).

This will enable servers to use UUIDs.
