### PR TITLE
Call error callback on ajax error unless offline

### DIFF
--- a/amd.header
+++ b/amd.header
@@ -1,9 +1,11 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['backbone'], factory);
+    return define(['backbone'], function(Backbone) {
+      return root.Backbone.DualStorage = factory(Backbone);
+    });
   } else if (typeof require === 'function' && ((typeof module !== "undefined" && module !== null ? module.exports : void 0) != null)) {
     return module.exports = factory(require('backbone'));
   } else {
-    factory(root.Backbone);
+    return root.Backbone.DualStorage = factory(root.Backbone);
   }
 })(this, function(Backbone) {

--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -6,7 +6,9 @@ persistence. Models are given GUIDS, and saved into a JSON object. Simple
 as that.
 ###
 
-Backbone.DualStorage = {}
+Backbone.DualStorage = {
+	defaultOfflineStatusCodes: [408, 502]
+}
 
 Backbone.Model.prototype.hasTempId = ->
   _.isString(@id) and @id.length is 36
@@ -266,9 +268,9 @@ dualsync = (method, model, options) ->
 
   relayErrorCallback = (response) ->
     relay = false
-    if response.status and offlineStatusCodes = Backbone.DualStorage.offlineStatusCodes
+    if response.status and offlineStatusCodes = (Backbone.DualStorage.offlineStatusCodes or Backbone.DualStorage.defaultOfflineStatusCodes)
       if _.isFunction(offlineStatusCodes)
-      	offlineStatusCodes = offlineStatusCodes response
+        offlineStatusCodes = offlineStatusCodes response
       relay = response.status not in offlineStatusCodes
     if relay
       error resp


### PR DESCRIPTION
- Expose `Backbone.DualStorage` as a namespace for this plugin's settings
- Treat Ajax status code `0` (instead of every error) to mean we're working offline
- Allow adding more status codes to mean the same using `Backbone.DualStorage.offlineStatusCodes` which is either an array of numbers or a function receiving `response` and returning an array of numbers
- Document `Backbone.DualStorage.offlineStatusCodes`
- Document how `options.dirty` can be examined in the `success` callback to determine whether the operation succeeded remotely (`false`) or only locally (`true`)

(edit: issue #67)
