### PR TITLE
Before the 'localsync' be called, call 'Model.parse' from user's original model instead 'modelClone', in 'modelUpdatedWithResponse' method

### DIFF
--- a/backbone.dualstorage.amd.js
+++ b/backbone.dualstorage.amd.js
@@ -326,7 +326,7 @@ modelUpdatedWithResponse = function(model, response) {
   modelClone = new Backbone.Model;
   modelClone.idAttribute = model.idAttribute;
   modelClone.set(model.attributes);
-  modelClone.set(modelClone.parse(response));
+  modelClone.set(model.parse(response));
   return modelClone;
 };
 

--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -234,7 +234,7 @@ modelUpdatedWithResponse = (model, response) ->
   modelClone = new Backbone.Model
   modelClone.idAttribute = model.idAttribute
   modelClone.set model.attributes
-  modelClone.set modelClone.parse response
+  modelClone.set model.parse response
   modelClone
 
 backboneSync = Backbone.sync

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -317,7 +317,7 @@ as that.
     modelClone = new Backbone.Model;
     modelClone.idAttribute = model.idAttribute;
     modelClone.set(model.attributes);
-    modelClone.set(modelClone.parse(response));
+    modelClone.set(model.parse(response));
     return modelClone;
   };
 

--- a/spec/backbone.dualstorage.js
+++ b/spec/backbone.dualstorage.js
@@ -315,7 +315,7 @@ modelUpdatedWithResponse = function(model, response) {
   modelClone = new Backbone.Model;
   modelClone.idAttribute = model.idAttribute;
   modelClone.set(model.attributes);
-  modelClone.set(modelClone.parse(response));
+  modelClone.set(model.parse(response));
   return modelClone;
 };
 


### PR DESCRIPTION
This ensures that the custom 'Model.parse' will be executed
