### PR TITLE
Expose original Backbone Sync to allow for customization of online sync method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### master / unreleased
 
+* Fix #123: Expose original BackboneSync as Backbone.DualStorage.originalSync to allow custom online sync methods (Richard Tibbles)
 * Fix #117: Don't generate temporary IDs that conflict with UUIDs (David Almilli)
 * Fix #115: Don't attempt to delete models from the server that were only local, and call the callback in this case (Micha Reiser)
 * Allow Backbone.DualStorage.offlineStatusCodes to include 200 OK as an offline status

--- a/backbone.dualstorage.amd.js
+++ b/backbone.dualstorage.amd.js
@@ -323,12 +323,12 @@ modelUpdatedWithResponse = function(model, response) {
   return modelClone;
 };
 
-backboneSync = Backbone.DualStorage.backboneSync = Backbone.sync;
+backboneSync = Backbone.DualStorage.originalSync = Backbone.sync;
 
 onlineSync = function(method, model, options) {
   options.success = callbackTranslator.forBackboneCaller(options.success);
   options.error = callbackTranslator.forBackboneCaller(options.error);
-  return Backbone.DualStorage.backboneSync(method, model, options);
+  return Backbone.DualStorage.originalSync(method, model, options);
 };
 
 dualsync = function(method, model, options) {

--- a/backbone.dualstorage.coffee
+++ b/backbone.dualstorage.coffee
@@ -235,11 +235,11 @@ modelUpdatedWithResponse = (model, response) ->
   modelClone.set model.parse response
   modelClone
 
-backboneSync = Backbone.DualStorage.backboneSync = Backbone.sync
+backboneSync = Backbone.DualStorage.originalSync = Backbone.sync
 onlineSync = (method, model, options) ->
   options.success = callbackTranslator.forBackboneCaller(options.success)
   options.error   = callbackTranslator.forBackboneCaller(options.error)
-  Backbone.DualStorage.backboneSync(method, model, options)
+  Backbone.DualStorage.originalSync(method, model, options)
 
 dualsync = (method, model, options) ->
   options.storeName = getStoreName(model.collection, model)

--- a/backbone.dualstorage.js
+++ b/backbone.dualstorage.js
@@ -316,12 +316,12 @@ as that.
     return modelClone;
   };
 
-  backboneSync = Backbone.DualStorage.backboneSync = Backbone.sync;
+  backboneSync = Backbone.DualStorage.originalSync = Backbone.sync;
 
   onlineSync = function(method, model, options) {
     options.success = callbackTranslator.forBackboneCaller(options.success);
     options.error = callbackTranslator.forBackboneCaller(options.error);
-    return Backbone.DualStorage.backboneSync(method, model, options);
+    return Backbone.DualStorage.originalSync(method, model, options);
   };
 
   dualsync = function(method, model, options) {

--- a/spec/backbone.dualstorage.js
+++ b/spec/backbone.dualstorage.js
@@ -314,12 +314,12 @@ modelUpdatedWithResponse = function(model, response) {
   return modelClone;
 };
 
-backboneSync = Backbone.DualStorage.backboneSync = Backbone.sync;
+backboneSync = Backbone.DualStorage.originalSync = Backbone.sync;
 
 onlineSync = function(method, model, options) {
   options.success = callbackTranslator.forBackboneCaller(options.success);
   options.error = callbackTranslator.forBackboneCaller(options.error);
-  return Backbone.DualStorage.backboneSync(method, model, options);
+  return Backbone.DualStorage.originalSync(method, model, options);
 };
 
 dualsync = function(method, model, options) {


### PR DESCRIPTION
Fixes #123.

Summary of changes:
- Call Backbone.DualStorage.originalSync within onlineSync method.
- Remake.
- Update CHANGES.md
